### PR TITLE
Obtain the public address of the CAS login server from the HTTP `Host` header

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine"
 	"io"
 	"net/url"
 )
@@ -15,9 +16,9 @@ func ValidateService(c echo.Context) *url.URL {
 	return service
 }
 
-func NewTemplateGlobal() *TemplateGlobal {
+func NewTemplateGlobal(request engine.Request) *TemplateGlobal {
 	templateGlobal := new(TemplateGlobal)
-	templateGlobal.CASLogin = GetCasLoginUrl("http://" + *OSFHost + "/dashboard")
+	templateGlobal.CASLogin = GetCasLoginUrl(request, "http://" + request.Host() + "/dashboard")
 	templateGlobal.OSFCreateAccount = GetOsfUrl("/register")
 	templateGlobal.OSFDomain = GetOsfUrl("/")
 	templateGlobal.OSFForgotPassword = GetOsfUrl("/forgotpassword")
@@ -34,8 +35,15 @@ func GetOsfUrl(path string) string {
 	return osfUrl.String()
 }
 
-func GetCasLoginUrl(service string) string {
-	casLogin, err := url.Parse("http://" + *Host + "/login?service=" + service)
+func GetCasLoginUrl(request engine.Request, service string) string {
+	host := *Host
+
+	if request != nil {
+		host = request.Host();
+	}
+
+	casLogin, err := url.Parse("http://" + host + "/login?service=" + service)
+
 	if err != nil {
 		panic(err)
 	}

--- a/views.go
+++ b/views.go
@@ -10,7 +10,7 @@ import (
 )
 
 func LoginPOST(c echo.Context) error {
-	data := NewTemplateGlobal()
+	data := NewTemplateGlobal(c.Request())
 
 	service := ValidateService(c)
 	if service == nil {
@@ -23,7 +23,7 @@ func LoginPOST(c echo.Context) error {
 		fmt.Println("User", c.FormValue("username"), "not found.")
 		data.LoginForm = true
 		data.NotExist = true
-		data.CASLogin = GetCasLoginUrl(service.String())
+		data.CASLogin = GetCasLoginUrl(c.Request(), service.String())
 		return c.Render(http.StatusOK, "login", data)
 	}
 
@@ -41,7 +41,7 @@ func LoginPOST(c echo.Context) error {
 }
 
 func LoginGET(c echo.Context) error {
-	data := NewTemplateGlobal()
+	data := NewTemplateGlobal(c.Request())
 
 	service := ValidateService(c)
 	if service == nil {
@@ -63,7 +63,7 @@ func LoginGET(c echo.Context) error {
 
 	if username.String() == "" && verification_key.String() == "" {
 		data.LoginForm = true
-		data.CASLogin = GetCasLoginUrl(service.String())
+		data.CASLogin = GetCasLoginUrl(c.Request(), service.String())
 		return c.Render(http.StatusOK, "login", data)
 	}
 


### PR DESCRIPTION
# Purpose

Enable proper handling the login form when fakecas is hosted behind a proxy.
# Changes

The parameters of `GetCasLoginUrl` and `NewTemplateGlobal` have been updated to accept an instance of an Echo `engine.Request`. 
- `NewTemplateGlobal` now requires an instance of `engine.Request`.  The HTTP `Host` header will be used to construct the CAS login url.
- `GetCasLoginUrl` optionally accepts a `nil` request object.  If the request object is `nil`, the bind address (`*Host`) will be used.  If the request object is present, the value of the HTTP `Host` header is used.
# Side effects

These changes break source and binary compatibility.  
# Ticket

Addresses #6 by obtaining the public address of the CAS login server from the HTTP `Host` header.
