### PR TITLE
[Feature] [On Hold] For New CAS [SVCS-451]

### DIFF
--- a/fakecas.go
+++ b/fakecas.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-  "github.com/labstack/echo"
-  "github.com/labstack/echo/middleware"
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
 	_ "github.com/lib/pq"
 	"html/template"
 	"os"
@@ -31,23 +31,26 @@ func main() {
 	}))
 	e.Use(middleware.Recover())
 
-  e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowCredentials: true,
-		AllowOrigins:   []string{"*"},
-		AllowMethods:   []string{"GET", "PUT", "POST", "DELETE"},
-		AllowHeaders:   []string{"Range", "Content-Type", "Authorization", "X-Requested-With"},
-		ExposeHeaders:   []string{"Range", "Content-Type", "Authorization", "X-Requested-With"},
+		AllowOrigins:     []string{"*"},
+		AllowMethods:     []string{"GET", "PUT", "POST", "DELETE"},
+		AllowHeaders:     []string{"Range", "Content-Type", "Authorization", "X-Requested-With"},
+		ExposeHeaders:    []string{"Range", "Content-Type", "Authorization", "X-Requested-With"},
 	}))
 
-	t, err := template.New("login").Parse(LOGINPAGE)
+	t, err := template.New("fakeCAS").Parse(TEMPLATES)
 	if err != nil {
 		panic(err)
 	}
+
 	temp := &Template{templates: t}
-  e.Renderer = temp
+	e.Renderer = temp
 
 	e.GET("/login", LoginGET)
 	e.POST("/login", LoginPOST)
+	e.GET("/account/register", RegisterGET)
+	// e.POST("/account/register", RegisterPOST)
 	e.GET("/logout", Logout)
 	e.GET("/oauth2/profile", OAuth)
 	e.GET("/p3/serviceValidate", ServiceValidate)
@@ -62,5 +65,5 @@ func main() {
 
 	defer DatabaseConnection.Close()
 
-  e.Start(*Host)
+	e.Start(*Host)
 }

--- a/fakecas.go
+++ b/fakecas.go
@@ -50,7 +50,7 @@ func main() {
 	e.GET("/login", LoginGET)
 	e.POST("/login", LoginPOST)
 	e.GET("/account/register", RegisterGET)
-	// e.POST("/account/register", RegisterPOST)
+	e.POST("/account/register", RegisterPOST)
 	e.GET("/logout", Logout)
 	e.GET("/oauth2/profile", OAuth)
 	e.GET("/p3/serviceValidate", ServiceValidate)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a29bdef36e4f569315d84b12a9fa49d4318d7bf7316927152c3cbb088cb7fee3
-updated: 2016-12-29T15:35:42.601592263-05:00
+updated: 2017-08-29T13:24:52.630265753-04:00
 imports:
 - name: github.com/dgrijalva/jwt-go
   version: f0777076321ab64f6efc15a82d9d23b98539b943

--- a/static.go
+++ b/static.go
@@ -1,6 +1,7 @@
 package main
 
-var LOGINPAGE = `{{define "login"}}
+var TEMPLATES = `
+{{define "login"}}
 
 <!DOCTYPE html>
 <html>
@@ -53,13 +54,66 @@ var LOGINPAGE = `{{define "login"}}
     <br>
     <div id="links">
       <section>
-        <a id="forgot-password" href={{.OSFForgotPassword}}>Forgot Your Password?</a><br>
-        <a id="institution-login" href={{.OSFInstitutionLogin}}>Login Through Your Institution</a><br>
         <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
-        <a id="create-account" href={{.OSFCreateAccount}}>Create Account</a>
+        <a id="create-account" href={{.CASRegister}}>Create Account</a>
       </section>
     </div>
   </body>
 </html>
 
-{{end}}`
+{{end}}
+
+{{define "register"}}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Open Science Framework | Sign Up</title>
+  </head>
+
+  <body>
+    <div id="header">
+      <span><h3>Open Science Framework | fakeCAS</h3></span>
+      <br>
+    </div>
+
+    {{if .NotAuthorized}}
+      <div id="message">
+        <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
+      </div>
+    {{end}}
+
+    {{if .RegisterForm}}
+      <div id="forms">
+        <form id="register" action="{{.CASRegister}}" method="post">
+          <section>
+            <span>Fullname:&nbsp;&nbsp;</span>
+            <input id="fullname" name="fullname" type="text" value="" size="" /><br><br>
+            <span>Email:&nbsp;&nbsp;</span>
+            <input id="email" name="email" type="text" value="" size="" /><br><br>
+            <span>Password:&nbsp;&nbsp;</span>
+            <input id="password" name="password" type="password" value="" size="" /><br><br>
+            <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
+            {{if .AlreadyRegistered}}
+              <span>  This email has already been registered.</span>
+            {{end}}
+            <br>
+          </section>
+          <section hidden>
+            <input id="persistence" name="persistence" type="checkbox" value="true" checked /><label id="persistence">Stay Signed In</label>
+          </section>
+        </form>
+      </div>
+    {{end}}
+    <br>
+    <div id="links">
+      <section>
+        <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
+        <a id="sign-in" href={{.CASLogin}}>Already have and account?</a><br>
+      </section>
+    </div>
+  </body>
+</html>
+
+{{end}}
+`

--- a/static.go
+++ b/static.go
@@ -15,31 +15,12 @@ var TEMPLATES = `
       <br>
     </div>
 
-    {{if .NotRegistered}}
-    <div id="message">
-      <p>This login email has been registered but not confirmed. Please check your email (and spam folder). <a href={{.OSFResendConfirmation}}>Click here</a> to resend your confirmation email.</p>
-    </div>
-    {{end}}
-
-    {{if .NotAuthorized}}
-    <div id="message">
-      <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
-    </div>
-    {{end}}
-
-    {{if .NotValid}}
-      <p>Invalid request. User does not exist or invalid/expired validation key.</p>
-    {{end}}
-    {{if .LoginForm}}
     <div id="forms">
       <form id="login" action="{{.CASLogin}}" method="post">
         <section>
           <span>Email:</span>&nbsp;&nbsp;
           <input id="username" name="username" type="text" value="" size="" />&nbsp;&nbsp;
           <input id="submit" type="submit" value="Sign In" />
-            {{if .NotExist}}
-            &nbsp;&nbsp;<span>User does not exist.</span>
-            {{end}}
         </section>
         <section hidden>
           <br>
@@ -48,9 +29,21 @@ var TEMPLATES = `
           <input id="persistence" name="persistence", type="checkbox" value="true" checked />
           <label id="for-persistence">Stay Signed In</label>
         </section>
+        <section>
+          <br>
+          <div id="message">
+            {{if .NotExist}}
+              <span>User does not exist.</span>
+            {{end}}
+            {{if .NotRegistered}}
+              <span>Login Failed. This login email has been registered but not confirmed.</span>
+            {{end}}
+          </div>
+        </section>
       </form>
+      <br>
     </div>
-    {{end}}
+
     <br>
     <div id="links">
       <section>
@@ -62,6 +55,7 @@ var TEMPLATES = `
 </html>
 
 {{end}}
+
 
 {{define "register"}}
 
@@ -77,45 +71,114 @@ var TEMPLATES = `
       <br>
     </div>
 
-    {{if .NotAuthorized}}
-      <div id="message">
-        <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
-      </div>
-    {{end}}
+    <div id="forms">
+      <form id="register" action="{{.CASRegister}}" method="post">
+        <section>
+          <span>Fullname:&nbsp;&nbsp;</span>
+          <input id="fullname" name="fullname" type="text" value="" size="" /><br><br>
+          <span>Email:&nbsp;&nbsp;</span>
+          <input id="email" name="email" type="text" value="" size="" /><br><br>
+          <span>Password:&nbsp;&nbsp;</span>
+          <input id="password" name="password" type="password" value="" size="" /><br><br>
+          <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
+        </section>
 
-    {{if .RegisterForm}}
-      <div id="forms">
-        <form id="register" action="{{.CASRegister}}" method="post">
-          <section>
-            <span>Fullname:&nbsp;&nbsp;</span>
-            <input id="fullname" name="fullname" type="text" value="" size="" /><br><br>
-            <span>Email:&nbsp;&nbsp;</span>
-            <input id="email" name="email" type="text" value="" size="" /><br><br>
-            <span>Password:&nbsp;&nbsp;</span>
-            <input id="password" name="password" type="password" value="" size="" /><br><br>
-            <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
-            {{if .RegisterSuccessful}}
-              <span>&nbsp;&nbsp;Registration Successful.</span><br>
-            {{end}}
-            {{if .ShowErrorMessages}}
-              <span>&nbsp;&nbsp;Request Failed!</span><br>
-            {{end}}
-          </section>
-          <section hidden>
-            <input id="persistence" name="persistence" type="checkbox" value="true" checked /><label id="persistence">Stay Signed In</label>
-          </section>
-        </form>
-      </div>
-    {{end}}
-    <br>
+        <section hidden>
+          <input id="persistence" name="persistence" type="checkbox" value="true" checked />
+          <label id="persistence">Stay Signed In</label>
+        </section>
+
+        <section>
+          {{if .RegisterSuccessful}}
+            <span>
+              &nbsp;&nbsp;A new OSF account has been created. Please <a href={{.CASLogin}}>log in</a> to continue.
+            </span>
+            <br>
+          {{end}}
+          {{if .ShowErrorMessages}}
+            <span>
+              &nbsp;&nbsp;Request to create an OSF account failed! Please take a look at the fakeCAS log.
+            </span><br>
+          {{end}}
+        </section>
+      </form>
+      <br>
+    </div>
+
     <div id="links">
       <section>
         <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
         <a id="sign-in" href={{.CASLogin}}>Already have and account?</a><br>
+      </section>
+      <br>
+    </div>
+  </body>
+
+</html>
+
+{{end}}
+
+
+
+{{define "unauthorized"}}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Open Science Framework | fakeCAS</title>
+  </head>
+
+  <body>
+    <div id="header">
+      <span><h3>Open Science Framework | fakeCAS</h3></span>
+      <br>
+    </div>
+
+    <div id="message">
+      <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
+      <br>
+    </div>
+
+    <div id="links">
+      <section>
+        <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
       </section>
     </div>
   </body>
 </html>
 
 {{end}}
+
+
+{{define "invalid"}}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Open Science Framework | fakeCAS</title>
+  </head>
+
+  <body>
+    <div id="header">
+      <span><h3>Open Science Framework | fakeCAS</h3></span>
+      <br>
+    </div>
+
+    <div id="message">
+      <p>Invalid request! User does not exist or invalid verification key.</p>
+      <br>
+    </div>
+
+    <div id="links">
+      <section>
+        <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
+        <a id="sign-in" href={{.CASLogin}}>Already have and account?</a><br>
+        <a id="create-account" href={{.CASRegister}}>Create Account</a>
+      </section>
+    </div>
+  </body>
+</html>
+
+{{end}}
+
 `

--- a/static.go
+++ b/static.go
@@ -94,10 +94,12 @@ var TEMPLATES = `
             <span>Password:&nbsp;&nbsp;</span>
             <input id="password" name="password" type="password" value="" size="" /><br><br>
             <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
-            {{if .AlreadyRegistered}}
-              <span>  This email has already been registered.</span>
+            {{if .RegisterSuccessful}}
+              <span>&nbsp;&nbsp;Registration Successful.</span><br>
             {{end}}
-            <br>
+            {{if .ShowErrorMessages}}
+              <span>&nbsp;&nbsp;Request Failed!</span><br>
+            {{end}}
           </section>
           <section hidden>
             <input id="persistence" name="persistence" type="checkbox" value="true" checked /><label id="persistence">Stay Signed In</label>

--- a/static/invalid.html
+++ b/static/invalid.html
@@ -1,0 +1,30 @@
+{{define "invalid"}}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Open Science Framework | fakeCAS</title>
+  </head>
+
+  <body>
+    <div id="header">
+      <span><h3>Open Science Framework | fakeCAS</h3></span>
+      <br>
+    </div>
+
+    <div id="message">
+      <p>Invalid request! User does not exist or invalid verification key.</p>
+      <br>
+    </div>
+
+    <div id="links">
+      <section>
+        <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
+        <a id="sign-in" href={{.CASLogin}}>Already have and account?</a><br>
+        <a id="create-account" href={{.CASRegister}}>Create Account</a>
+      </section>
+    </div>
+  </body>
+</html>
+
+{{end}}

--- a/static/login.html
+++ b/static/login.html
@@ -12,31 +12,12 @@
       <br>
     </div>
 
-    {{if .NotRegistered}}
-    <div id="message">
-      <p>This login email has been registered but not confirmed. Please check your email (and spam folder). <a href={{.OSFResendConfirmation}}>Click here</a> to resend your confirmation email.</p>
-    </div>
-    {{end}}
-
-    {{if .NotAuthorized}}
-    <div id="message">
-      <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
-    </div>
-    {{end}}
-
-    {{if .NotValid}}
-      <p>Invalid request. User does not exist or invalid/expired validation key.</p>
-    {{end}}
-    {{if .LoginForm}}
     <div id="forms">
       <form id="login" action="{{.CASLogin}}" method="post">
         <section>
           <span>Email:</span>&nbsp;&nbsp;
           <input id="username" name="username" type="text" value="" size="" />&nbsp;&nbsp;
           <input id="submit" type="submit" value="Sign In" />
-            {{if .NotExist}}
-            &nbsp;&nbsp;<span>User does not exist.</span>
-            {{end}}
         </section>
         <section hidden>
           <br>
@@ -45,9 +26,21 @@
           <input id="persistence" name="persistence", type="checkbox" value="true" checked />
           <label id="for-persistence">Stay Signed In</label>
         </section>
+        <section>
+          <br>
+          <div id="message">
+            {{if .NotExist}}
+              <span>User does not exist.</span>
+            {{end}}
+            {{if .NotRegistered}}
+              <span>Login Failed. This login email has been registered but not confirmed.</span>
+            {{end}}
+          </div>
+        </section>
       </form>
+      <br>
     </div>
-    {{end}}
+
     <br>
     <div id="links">
       <section>

--- a/static/login.html
+++ b/static/login.html
@@ -51,10 +51,8 @@
     <br>
     <div id="links">
       <section>
-        <a id="forgot-password" href={{.OSFForgotPassword}}>Forgot Your Password?</a><br>
-        <a id="institution-login" href={{.OSFInstitutionLogin}}>Login Through Your Institution</a><br>
         <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
-        <a id="create-account" href={{.OSFCreateAccount}}>Create Account</a>
+        <a id="create-account" href={{.CASRegister}}>Create Account</a>
       </section>
     </div>
   </body>

--- a/static/register.html
+++ b/static/register.html
@@ -2,6 +2,7 @@
 
 <!DOCTYPE html>
 <html>
+
   <head>
     <title>Open Science Framework | Sign Up</title>
   </head>
@@ -12,44 +13,50 @@
       <br>
     </div>
 
-    {{if .NotAuthorized}}
-      <div id="message">
-        <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
-      </div>
-    {{end}}
+    <div id="forms">
+      <form id="register" action="{{.CASRegister}}" method="post">
+        <section>
+          <span>Fullname:&nbsp;&nbsp;</span>
+          <input id="fullname" name="fullname" type="text" value="" size="" /><br><br>
+          <span>Email:&nbsp;&nbsp;</span>
+          <input id="email" name="email" type="text" value="" size="" /><br><br>
+          <span>Password:&nbsp;&nbsp;</span>
+          <input id="password" name="password" type="password" value="" size="" /><br><br>
+          <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
+        </section>
 
-    {{if .RegisterForm}}
-      <div id="forms">
-        <form id="register" action="{{.CASRegister}}" method="post">
-          <section>
-            <span>Fullname:&nbsp;&nbsp;</span>
-            <input id="fullname" name="fullname" type="text" value="" size="" /><br><br>
-            <span>Email:&nbsp;&nbsp;</span>
-            <input id="email" name="email" type="text" value="" size="" /><br><br>
-            <span>Password:&nbsp;&nbsp;</span>
-            <input id="password" name="password" type="password" value="" size="" /><br><br>
-            <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
-            {{if .RegisterSuccessful}}
-              <span>&nbsp;&nbsp;Registration Successful.</span><br>
-            {{end}}
-            {{if .ShowErrorMessages}}
-              <span>&nbsp;&nbsp;Request Failed!</span><br>
-            {{end}}
-          </section>
-          <section hidden>
-            <input id="persistence" name="persistence" type="checkbox" value="true" checked /><label id="persistence">Stay Signed In</label>
-          </section>
-        </form>
-      </div>
-    {{end}}
-    <br>
+        <section hidden>
+          <input id="persistence" name="persistence" type="checkbox" value="true" checked />
+          <label id="persistence">Stay Signed In</label>
+        </section>
+
+        <section>
+          {{if .RegisterSuccessful}}
+            <span>
+              &nbsp;&nbsp;A new OSF account has been created. Please <a href={{.CASLogin}}>log in</a> to continue.
+            </span>
+            <br>
+          {{end}}
+          {{if .ShowErrorMessages}}
+            <span>
+              &nbsp;&nbsp;Request to create an OSF account failed! Please take a look at the fakeCAS log.
+            </span><br>
+          {{end}}
+        </section>
+      </form>
+      <br>
+    </div>
+
     <div id="links">
       <section>
         <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
         <a id="sign-in" href={{.CASLogin}}>Already have and account?</a><br>
       </section>
+      <br>
     </div>
+
   </body>
+
 </html>
 
 {{end}}

--- a/static/register.html
+++ b/static/register.html
@@ -1,0 +1,53 @@
+{{define "register"}}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Open Science Framework | Sign Up</title>
+  </head>
+
+  <body>
+    <div id="header">
+      <span><h3>Open Science Framework | fakeCAS</h3></span>
+      <br>
+    </div>
+
+    {{if .NotAuthorized}}
+      <div id="message">
+        <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
+      </div>
+    {{end}}
+
+    {{if .RegisterForm}}
+      <div id="forms">
+        <form id="register" action="{{.CASRegister}}" method="post">
+          <section>
+            <span>Fullname:&nbsp;&nbsp;</span>
+            <input id="fullname" name="fullname" type="text" value="" size="" /><br><br>
+            <span>Email:&nbsp;&nbsp;</span>
+            <input id="email" name="email" type="text" value="" size="" /><br><br>
+            <span>Password:&nbsp;&nbsp;</span>
+            <input id="password" name="password" type="password" value="" size="" /><br><br>
+            <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
+            {{if .AlreadyRegistered}}
+              <span>  This email has already been registered.</span>
+            {{end}}
+            <br>
+          </section>
+          <section hidden>
+            <input id="persistence" name="persistence" type="checkbox" value="true" checked /><label id="persistence">Stay Signed In</label>
+          </section>
+        </form>
+      </div>
+    {{end}}
+    <br>
+    <div id="links">
+      <section>
+        <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
+        <a id="sign-in" href={{.CASLogin}}>Already have and account?</a><br>
+      </section>
+    </div>
+  </body>
+</html>
+
+{{end}}

--- a/static/register.html
+++ b/static/register.html
@@ -29,10 +29,12 @@
             <span>Password:&nbsp;&nbsp;</span>
             <input id="password" name="password" type="password" value="" size="" /><br><br>
             <input id="submit" type="submit" value="Create Your OSF Account" /><br><br>
-            {{if .AlreadyRegistered}}
-              <span>  This email has already been registered.</span>
+            {{if .RegisterSuccessful}}
+              <span>&nbsp;&nbsp;Registration Successful.</span><br>
             {{end}}
-            <br>
+            {{if .ShowErrorMessages}}
+              <span>&nbsp;&nbsp;Request Failed!</span><br>
+            {{end}}
           </section>
           <section hidden>
             <input id="persistence" name="persistence" type="checkbox" value="true" checked /><label id="persistence">Stay Signed In</label>

--- a/static/unauthorized.html
+++ b/static/unauthorized.html
@@ -1,0 +1,28 @@
+{{define "unauthorized"}}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Open Science Framework | fakeCAS</title>
+  </head>
+
+  <body>
+    <div id="header">
+      <span><h3>Open Science Framework | fakeCAS</h3></span>
+      <br>
+    </div>
+
+    <div id="message">
+      <p>The service you attempted to authenticate to is not authorized to use CAS.</p>
+      <br>
+    </div>
+
+    <div id="links">
+      <section>
+        <a id="back-to-osf" href={{.OSFDomain}}>Back to OSF</a><br>
+      </section>
+    </div>
+  </body>
+</html>
+
+{{end}}

--- a/types.go
+++ b/types.go
@@ -54,13 +54,14 @@ type Template struct {
 
 type TemplateGlobal struct {
 	// login flow
-	LoginForm         bool
-	RegisterForm      bool
-	NotExist          bool
-	NotValid          bool
-	NotAuthorized     bool
-	NotRegistered     bool
-	AlreadyRegistered bool
+	LoginForm          bool
+	RegisterForm       bool
+	NotExist           bool
+	NotValid           bool
+	NotAuthorized      bool
+	NotRegistered      bool
+	RegisterSuccessful bool
+	ShowErrorMessages  bool
 	// cas url
 	CASLogin    string
 	CASRegister string

--- a/types.go
+++ b/types.go
@@ -54,12 +54,10 @@ type Template struct {
 
 type TemplateGlobal struct {
 	// login flow
-	LoginForm          bool
-	RegisterForm       bool
-	NotExist           bool
-	NotValid           bool
-	NotAuthorized      bool
-	NotRegistered      bool
+	NotExist      bool
+	NotValid      bool
+	NotRegistered bool
+	// register flow
 	RegisterSuccessful bool
 	ShowErrorMessages  bool
 	// cas url

--- a/types.go
+++ b/types.go
@@ -17,14 +17,14 @@ type OAuthResponse struct {
 }
 
 type User struct {
-	Id              string `bson:"_id"`
-	Username        string `bson:"username"`
-	Fullname        string `bson:"fullname"`
-	GivenName       string `bson:"given_name"`
-	FamilyName      string `bson:"family_name"`
-	IsRegistered    bool   `bson:"is_registered"`
-	Password        string `bson:"password"`
-	VerificationKey string `bson:"verification_key"`
+	Id              string `"_id"`
+	Username        string `"username"`
+	Fullname        string `"fullname"`
+	GivenName       string `"given_name"`
+	FamilyName      string `"family_name"`
+	IsRegistered    bool   `"is_registered"`
+	Password        string `"password"`
+	VerificationKey string `"verification_key"`
 }
 
 type ServiceResponse struct {
@@ -42,10 +42,10 @@ type ServiceResponse struct {
 }
 
 type AccessToken struct {
-	Id      string `bson:"_id"`
-	Owner   string `bson:"owner"`
-	TokenId string `bson:"token_id"`
-	Scopes  string `bson:"scopes"`
+	Id      string `"_id"`
+	Owner   string `"owner"`
+	TokenId string `"token_id"`
+	Scopes  string `"scopes"`
 }
 
 type Template struct {

--- a/types.go
+++ b/types.go
@@ -23,6 +23,7 @@ type User struct {
 	GivenName       string `bson:"given_name"`
 	FamilyName      string `bson:"family_name"`
 	IsRegistered    bool   `bson:"is_registered"`
+	Password        string `bson:"password"`
 	VerificationKey string `bson:"verification_key"`
 }
 
@@ -53,15 +54,17 @@ type Template struct {
 
 type TemplateGlobal struct {
 	// login flow
-	LoginForm     bool
-	NotExist      bool
-	NotValid      bool
-	NotAuthorized bool
-	NotRegistered bool
+	LoginForm         bool
+	RegisterForm      bool
+	NotExist          bool
+	NotValid          bool
+	NotAuthorized     bool
+	NotRegistered     bool
+	AlreadyRegistered bool
 	// cas url
-	CASLogin string
+	CASLogin    string
+	CASRegister string
 	// osf url
-	OSFCreateAccount      string
 	OSFDomain             string
 	OSFForgotPassword     string
 	OSFInstitutionLogin   string

--- a/utils.go
+++ b/utils.go
@@ -11,6 +11,8 @@ func ValidateService(c echo.Context) *url.URL {
 	// TODO: add service validation if needed
 	if err != nil {
 		service = nil
+	} else if service.Host == "" || service.Path == "" {
+		service = nil
 	}
 	return service
 }
@@ -20,13 +22,8 @@ func NewTemplateGlobal() *TemplateGlobal {
 	templateGlobal.CASLogin = GetCasLoginUrl("http://" + *OSFHost + "/dashboard")
 	templateGlobal.CASRegister = GetCasRegisterUrl("http://" + *OSFHost + "/dashboard")
 	templateGlobal.OSFDomain = GetOsfUrl("/")
-	templateGlobal.OSFForgotPassword = GetOsfUrl("/forgotpassword")
-	templateGlobal.OSFInstitutionLogin = GetOsfUrl("/login?campaign=institution")
-	templateGlobal.OSFResendConfirmation = GetOsfUrl("/resend")
-	templateGlobal.RegisterForm = true
 	templateGlobal.RegisterSuccessful = false
 	templateGlobal.ShowErrorMessages = false
-	templateGlobal.NotAuthorized = false
 	return templateGlobal
 }
 

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,7 @@ func ValidateService(c echo.Context) *url.URL {
 func NewTemplateGlobal() *TemplateGlobal {
 	templateGlobal := new(TemplateGlobal)
 	templateGlobal.CASLogin = GetCasLoginUrl("http://" + *OSFHost + "/dashboard")
-	templateGlobal.OSFCreateAccount = GetOsfUrl("/register")
+	templateGlobal.CASRegister = GetCasRegisterUrl("http://" + *OSFHost + "/dashboard")
 	templateGlobal.OSFDomain = GetOsfUrl("/")
 	templateGlobal.OSFForgotPassword = GetOsfUrl("/forgotpassword")
 	templateGlobal.OSFInstitutionLogin = GetOsfUrl("/login?campaign=institution")
@@ -36,6 +36,10 @@ func GetOsfUrl(path string) string {
 
 func GetCasLoginUrl(service string) string {
 	return "/login?service=" + url.QueryEscape(service)
+}
+
+func GetCasRegisterUrl(service string) string {
+	return "/account/register?service=" + url.QueryEscape(service)
 }
 
 func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Context) error {

--- a/utils.go
+++ b/utils.go
@@ -23,6 +23,10 @@ func NewTemplateGlobal() *TemplateGlobal {
 	templateGlobal.OSFForgotPassword = GetOsfUrl("/forgotpassword")
 	templateGlobal.OSFInstitutionLogin = GetOsfUrl("/login?campaign=institution")
 	templateGlobal.OSFResendConfirmation = GetOsfUrl("/resend")
+	templateGlobal.RegisterForm = true
+	templateGlobal.RegisterSuccessful = false
+	templateGlobal.ShowErrorMessages = false
+	templateGlobal.NotAuthorized = false
 	return templateGlobal
 }
 

--- a/views.go
+++ b/views.go
@@ -17,8 +17,7 @@ func RegisterGET(c echo.Context) error {
 
 	service := ValidateService(c)
 	if service == nil {
-		data.NotAuthorized = true
-		return c.Render(http.StatusUnauthorized, "register", data)
+		return c.Render(http.StatusUnauthorized, "unauthorized", data)
 	}
 	data.CASRegister = GetCasRegisterUrl(service.String())
 	data.CASLogin = GetCasLoginUrl(service.String())
@@ -31,8 +30,7 @@ func RegisterPOST(c echo.Context) error {
 
 	service := ValidateService(c)
 	if service == nil {
-		data.NotAuthorized = true
-		return c.Render(http.StatusUnauthorized, "register", data)
+		return c.Render(http.StatusUnauthorized, "unauthorized", data)
 	}
 	data.CASRegister = GetCasRegisterUrl(service.String())
 	data.CASLogin = GetCasLoginUrl(service.String())
@@ -67,9 +65,10 @@ func LoginPOST(c echo.Context) error {
 
 	service := ValidateService(c)
 	if service == nil {
-		data.NotAuthorized = true
-		return c.Render(http.StatusUnauthorized, "login", data)
+		return c.Render(http.StatusUnauthorized, "unauthorized", data)
 	}
+	data.CASRegister = GetCasRegisterUrl(service.String())
+	data.CASLogin = GetCasLoginUrl(service.String())
 
 	var isRegistered bool
 	username := strings.ToLower(strings.TrimSpace(c.FormValue("username")))
@@ -87,9 +86,7 @@ func LoginPOST(c echo.Context) error {
 			panic(err)
 		}
 		fmt.Println("User", username, "not found.")
-		data.LoginForm = true
 		data.NotExist = true
-		data.CASLogin = GetCasLoginUrl(service.String())
 		return c.Render(http.StatusOK, "login", data)
 	}
 
@@ -111,9 +108,10 @@ func LoginGET(c echo.Context) error {
 
 	service := ValidateService(c)
 	if service == nil {
-		data.NotAuthorized = true
-		return c.Render(http.StatusUnauthorized, "login", data)
+		return c.Render(http.StatusUnauthorized, "unauthorized", data)
 	}
+	data.CASRegister = GetCasRegisterUrl(service.String())
+	data.CASLogin = GetCasLoginUrl(service.String())
 
 	username, err := url.Parse(c.QueryParam("username"))
 	if err != nil {
@@ -128,7 +126,6 @@ func LoginGET(c echo.Context) error {
 	}
 
 	if username.String() == "" && verificationKey.String() == "" {
-		data.LoginForm = true
 		data.CASLogin = GetCasLoginUrl(service.String())
 		return c.Render(http.StatusOK, "login", data)
 	}
@@ -147,8 +144,7 @@ func LoginGET(c echo.Context) error {
 			panic(err)
 		}
 		fmt.Println("User", uname, "not found.")
-		data.NotValid = true
-		return c.Render(http.StatusNotFound, "login", data)
+		return c.Render(http.StatusNotFound, "invalid", data)
 	}
 
 	// fakeCAS will check verification key

--- a/views.go
+++ b/views.go
@@ -9,6 +9,22 @@ import (
 	"strings"
 )
 
+func RegisterGET(c echo.Context) error {
+
+	data := NewTemplateGlobal()
+
+	service := ValidateService(c)
+	if service == nil {
+		data.NotAuthorized = true
+		return c.Render(http.StatusUnauthorized, "register", data)
+	}
+	data.CASRegister = GetCasRegisterUrl(service.String())
+	data.CASLogin = GetCasLoginUrl(service.String())
+
+	data.RegisterForm = true
+	return c.Render(http.StatusOK, "register", data)
+}
+
 func LoginPOST(c echo.Context) error {
 	data := NewTemplateGlobal()
 

--- a/views.go
+++ b/views.go
@@ -41,12 +41,11 @@ func RegisterPOST(c echo.Context) error {
 	email := strings.ToLower(strings.TrimSpace(c.FormValue("email")))
 	password := c.FormValue("password")
 
-	api_v1_url_for_register_user := "http://" + *OSFHost + "/api/v1/register/"
-	jsonStr := "{\"email1\": \"" + email + "\", \"email2\": \"" + email + "\", \"password\": \"" + password + "\", \"fullName\": \"" + fullname + "\"}"
+	api_v1_url_for_register_user := fmt.Sprintf("http://%s/api/v1/register/", *OSFHost)
+	jsonStr := fmt.Sprintf("{\"email1\": \"%s\", \"email2\": \"%s\", \"password\": \"%s\", \"fullName\": \"%s\"}", email, email, password, fullname)
 	byteStr := []byte(jsonStr)
 	resp, err := http.Post(api_v1_url_for_register_user, "application/json", bytes.NewBuffer(byteStr))
 	if err != nil {
-		panic(err)
 		data.ShowErrorMessages = true
 		return c.Render(http.StatusOK, "register", data)
 	}

--- a/views.go
+++ b/views.go
@@ -39,10 +39,11 @@ func RegisterPOST(c echo.Context) error {
 	email := strings.ToLower(strings.TrimSpace(c.FormValue("email")))
 	password := c.FormValue("password")
 
-	api_v1_url_for_register_user := fmt.Sprintf("http://%s/api/v1/register/", *OSFHost)
-	jsonStr := fmt.Sprintf("{\"email1\": \"%s\", \"email2\": \"%s\", \"password\": \"%s\", \"fullName\": \"%s\"}", email, email, password, fullname)
+	// fakeCAS uses OSF route "register_user" (v1 api) to create a confirmed user
+	registerUserUrl := fmt.Sprintf("http://%s/api/v1/register/", *OSFHost)
+	jsonStr := fmt.Sprintf(`{"email1": "%s", "email2": "%s", "password": "%s", "fullName": "%s"}`, email, email, password, fullname)
 	byteStr := []byte(jsonStr)
-	resp, err := http.Post(api_v1_url_for_register_user, "application/json", bytes.NewBuffer(byteStr))
+	resp, err := http.Post(registerUserUrl, "application/json", bytes.NewBuffer(byteStr))
 	if err != nil {
 		data.ShowErrorMessages = true
 		return c.Render(http.StatusOK, "register", data)


### PR DESCRIPTION
### Purpose

Update fakeCAS for the new CAS.

### Changes

Add register flow/view, which uses API V1 `register_user()` to create confirmed user when `FAKECAS_MODE` is on. (No confirmation is needed.)

![fakecas-register](https://user-images.githubusercontent.com/3750414/30551872-0bcd5014-9c6a-11e7-8320-7faeab3c2097.png)

![fakecas-register-success](https://user-images.githubusercontent.com/3750414/30551877-10b08524-9c6a-11e7-8c6b-9e7e7fb16521.png)

![fakecas-register-error](https://user-images.githubusercontent.com/3750414/30551882-15169a22-9c6a-11e7-8142-81354a065f2b.png)

![fakecas-register-invalid-service](https://user-images.githubusercontent.com/3750414/30551930-3e6f8384-9c6a-11e7-9d41-1cd53db17932.png)

### Tickets and PRs

Service Ticket: https://openscience.atlassian.net/browse/SVCS-451
OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/7652

### Deployment Notes

- [ ] Blocked by: https://github.com/CenterForOpenScience/osf.io/pull/7344 and https://github.com/CenterForOpenScience/cas-overlay/pull/64
