### PR TITLE
[ENG-345] Add "oauth/revoke" to fakeCAS

### DIFF
--- a/fakecas.go
+++ b/fakecas.go
@@ -51,6 +51,7 @@ func main() {
 	e.POST("/login", LoginPOST)
 	e.GET("/logout", Logout)
 	e.GET("/oauth2/profile", OAuth)
+	e.POST("/oauth2/revoke", OAuthRevoke)
 	e.GET("/p3/serviceValidate", ServiceValidate)
 
 	fmt.Println("Expecting database", *DatabaseName, "to be running at", *DatabaseAddress)

--- a/views.go
+++ b/views.go
@@ -238,3 +238,7 @@ func OAuth(c echo.Context) error {
 		Scope: scopes,
 	})
 }
+
+func OAuthRevoke(c echo.Context) error {
+	return c.NoContent(http.StatusNoContent)
+}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-345

## Purpose

Add "oauth/revoke" to fakeCAS so that locally developers can update and revoke PATs.

## Changes

Simply added a route `/oauth/revoke` that returns `HTTP 204` since fakeCAS does
not maintain its own database to store tokens.

## Side effects

No

## QA Notes

DevQA: please test this locally with CenterForOpenScience/osf.io#8766.

## Deployment Notes

- [x] Can be merged into develop ahead of CenterForOpenScience/osf.io#8766.
