### PR TITLE
[ENG-719] OAuth Profile Should Return a 404 on Deactivated Tokens

### DIFF
--- a/views.go
+++ b/views.go
@@ -180,7 +180,7 @@ func OAuth(c echo.Context) error {
 				ON django_content_type.id = osf_guid.content_type_id AND object_id = osf_osfuser.id
 			JOIN osf_apioauth2personaltoken
 				ON osf_osfuser.id = osf_apioauth2personaltoken.owner_id
-		WHERE osf_apioauth2personaltoken.token_id = $1
+		WHERE osf_apioauth2personaltoken.token_id = $1 AND osf_apioauth2personaltoken.is_active
 	`
 	err := DatabaseConnection.QueryRow(queryString, tokenId).Scan(&result.Id, &result.Username, &result.GivenName, &result.FamilyName)
 	if err != nil {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-719

## Purpose

Profiling a revoked PAT should return a 404 instead of the token info. OSF never deletes the token from DB but flags it as `in_active`.

## Changes

Updated the query to respect the `in_active` field.

## Side effects

No

## QA Notes

DevQA: please test this locally with CenterForOpenScience/osf.io#8766.

## Deployment Notes

- [x] Can be merged into develop ahead of CenterForOpenScience/osf.io#8766.
